### PR TITLE
feat: Allow font-family to be overridden with a variable

### DIFF
--- a/index.css
+++ b/index.css
@@ -16,7 +16,7 @@
 }
 .NotFoundHandler svg text{
   font-size: 95px;
-  font-family: Georgia;
+  font-family: var(--notfound-font, Georgia);
 }
 .NotFoundHandler path {
   opacity: .6;


### PR DESCRIPTION
This enables fe-blogs to use its own font by passing it from the outside as a variable.